### PR TITLE
Add static and testrunner imports

### DIFF
--- a/basic/bootstrap4/app/init.go
+++ b/basic/bootstrap4/app/init.go
@@ -1,9 +1,10 @@
 package app
 
 import (
-	"github.com/revel/revel"
 	_ "github.com/revel/modules"
-
+	_ "github.com/revel/modules/static"
+	_ "github.com/revel/modules/testrunner"
+	"github.com/revel/revel"
 )
 
 var (


### PR DESCRIPTION
## Description
This imports the `static` and `testrunner` modules to prevent an issue with Go
modules where these revel modules are not found after creating a new project,
like e.g.:

```
ERROR 09:18:35  revel.go:107: Unable to execute
error="Revel paths[error Failed to load module.  Import of path failed
modulePath:github.com/revel/modules/testrunner error:No files found in import
path github.com/revel/modules/testrunner ]"
```

## Errors from a new project

```
⋊> ~/g/s/g/a/n/portal on main ◦ revel run
Revel executing: run a Revel application
Downloading related packages ... completed.
ERROR 09:18:35  revel.go:107: Unable to execute                        error="Revel paths[error Failed to load module.  Import of path failed modulePath:github.com/revel/modules/testrunner error:No files found in import path github.com/revel/modules/testrunner ]" 
```